### PR TITLE
Onboarding: Progress save

### DIFF
--- a/src/components/Onboarding/Deployment/Boxes.js
+++ b/src/components/Onboarding/Deployment/Boxes.js
@@ -228,7 +228,7 @@ BoxProgress.propTypes = {
   ).isRequired,
 }
 
-export function BoxReady({ isFinalized, onOpenGarden, opacity, boxTransform }) {
+export function BoxReady({ isFinalized, onGetStarted, opacity, boxTransform }) {
   const { below } = useViewport()
   const fullWidth = below('large')
   const small = below('medium')
@@ -266,7 +266,7 @@ export function BoxReady({ isFinalized, onOpenGarden, opacity, boxTransform }) {
               <Button
                 label="Get started"
                 mode="strong"
-                onClick={onOpenGarden}
+                onClick={onGetStarted}
                 css={`
                   margin-top: ${2 * GU}px;
                 `}
@@ -288,7 +288,7 @@ export function BoxReady({ isFinalized, onOpenGarden, opacity, boxTransform }) {
 }
 
 BoxReady.propTypes = {
-  onOpenGarden: PropTypes.func.isRequired,
+  onGetStarted: PropTypes.func.isRequired,
   opacity: PropTypes.object.isRequired,
   boxTransform: PropTypes.object.isRequired,
 }

--- a/src/components/Onboarding/Deployment/Deployment.js
+++ b/src/components/Onboarding/Deployment/Deployment.js
@@ -26,15 +26,17 @@ const Deployment = React.memo(function Deployment() {
     gardenAddress,
     isFinalized,
     onNextAttempt,
+    onReset,
     readyToStart,
     transactionsStatus,
   } = useDeploymentState()
 
-  const handleOpenGarden = useCallback(() => {
+  const handleGetStarted = useCallback(() => {
     if (gardenAddress && isFinalized) {
       history.push(`/garden/${gardenAddress}`)
+      onReset()
     }
-  }, [gardenAddress, history, isFinalized])
+  }, [gardenAddress, history, isFinalized, onReset])
 
   const [pending, allSuccess] = useMemo(() => {
     if (transactionsStatus.length === 0) {
@@ -130,7 +132,7 @@ const Deployment = React.memo(function Deployment() {
                 allSuccess ? (
                   <BoxReady
                     isFinalized={isFinalized}
-                    onOpenGarden={handleOpenGarden}
+                    onGetStarted={handleGetStarted}
                     opacity={opacity}
                     boxTransform={transform}
                   />

--- a/src/components/Onboarding/Deployment/useDeploymentState.js
+++ b/src/components/Onboarding/Deployment/useDeploymentState.js
@@ -19,7 +19,12 @@ const DEFAULT_TX_PROGRESS = {
 
 export default function useDeploymentState() {
   const { account, ethers } = useWallet()
-  const { deployTransactions, gardenAddress, status } = useOnboardingState()
+  const {
+    deployTransactions,
+    gardenAddress,
+    onReset,
+    status,
+  } = useOnboardingState()
 
   const [attempts, setAttempts] = useState(0)
   const [transactionProgress, setTransactionProgress] = useState(
@@ -134,6 +139,7 @@ export default function useDeploymentState() {
     gardenAddress,
     isFinalized: status === STATUS_GARDEN_CREATED,
     onNextAttempt: handleNextAttempt,
+    onReset,
     readyToStart: deployTransactions.length > 0,
     transactionsStatus,
   }

--- a/src/components/Onboarding/SavedProgress.js
+++ b/src/components/Onboarding/SavedProgress.js
@@ -43,7 +43,7 @@ function SavedProgress() {
             margin-top: ${2 * GU}px;
           `}
         >
-          You have a saved progress! Would you like to pick up from where you
+          You have saved progress! Would you like to pick up from where you
           left of?
         </p>
         <div

--- a/src/components/Onboarding/SavedProgress.js
+++ b/src/components/Onboarding/SavedProgress.js
@@ -43,8 +43,8 @@ function SavedProgress() {
             margin-top: ${2 * GU}px;
           `}
         >
-          You have saved progress! Would you like to pick up from where you
-          left of?
+          You have saved progress! Would you like to pick up from where you left
+          of?
         </p>
         <div
           css={`

--- a/src/components/Onboarding/SavedProgress.js
+++ b/src/components/Onboarding/SavedProgress.js
@@ -1,0 +1,65 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Box, Button, GU, textStyle } from '@1hive/1hive-ui'
+import { useOnboardingState } from '@providers/Onboarding'
+
+function SavedProgress() {
+  const { progress, step } = useOnboardingState()
+  const [visible, setVisible] = useState(progress.hasSavedProgress)
+
+  const handleHideProgress = useCallback(() => {
+    setVisible(false)
+  }, [])
+
+  useEffect(() => {
+    if (progress.resumed || step > 0) {
+      handleHideProgress()
+    }
+  }, [handleHideProgress, progress.resumed, step])
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div
+      css={`
+        position: absolute;
+        top: 85%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      `}
+    >
+      <Box>
+        <h1
+          css={`
+            ${textStyle('title3')};
+          `}
+        >
+          Saved progress
+        </h1>
+        <p
+          css={`
+            ${textStyle('title4')};
+            margin-top: ${2 * GU}px;
+          `}
+        >
+          You have a saved progress! Would you like to pick up from where you
+          left of?
+        </p>
+        <div
+          css={`
+            margin-top: ${3 * GU}px;
+            display: flex;
+            align-items: center;
+            column-gap: ${1 * GU}px;
+          `}
+        >
+          <Button label="Yes" mode="strong" wide onClick={progress.onResume} />
+          <Button label="No" mode="normal" wide onClick={handleHideProgress} />
+        </div>
+      </Box>
+    </div>
+  )
+}
+
+export default SavedProgress

--- a/src/components/Onboarding/Setup.js
+++ b/src/components/Onboarding/Setup.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { GU, IconCross, useTheme } from '@1hive/1hive-ui'
+import SavedProgress from './SavedProgress'
 import Screens from './Screens'
 import StepsPanel from './Steps/StepsPanel'
 
@@ -59,6 +60,8 @@ function Setup({ onClose }) {
           css={`
             overflow-y: auto;
             height: calc(100vh - 127px);
+
+            position: relative;
           `}
         >
           <section
@@ -77,6 +80,7 @@ function Setup({ onClose }) {
               <Screens />
             </div>
           </section>
+          <SavedProgress />
         </div>
       </div>
     </>

--- a/src/components/Onboarding/Setup.js
+++ b/src/components/Onboarding/Setup.js
@@ -60,7 +60,6 @@ function Setup({ onClose }) {
           css={`
             overflow-y: auto;
             height: calc(100vh - 127px);
-
             position: relative;
           `}
         >

--- a/src/components/Onboarding/hooks/useProgressSaver.js
+++ b/src/components/Onboarding/hooks/useProgressSaver.js
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useWallet } from '@providers/Wallet'
+
+import {
+  getItem,
+  recoverAssets,
+  removeItem,
+  setItem,
+} from '../utils/progress-utils'
+
+export default function useProgressSaver(onConfigChange, onStepChange) {
+  const { account } = useWallet()
+  const [resumed, setResumed] = useState(false)
+
+  const handleClearProgress = useCallback(() => {
+    removeItem(account)
+  }, [account])
+
+  const handleResume = useCallback(() => {
+    setResumed(true)
+  }, [])
+
+  const handleSaveConfig = useCallback(
+    config => {
+      const progress = getItem(account)
+      setItem(account, { ...progress, config })
+    },
+    [account]
+  )
+
+  const handleSaveStep = useCallback(
+    step => {
+      const progress = getItem(account)
+      setItem(account, { ...progress, step })
+    },
+    [account]
+  )
+
+  useEffect(() => {
+    if (!resumed) {
+      return
+    }
+
+    const progress = getItem(account)
+    if (progress) {
+      onConfigChange(recoverAssets(progress.config))
+      onStepChange(progress.step)
+    }
+  }, [account, onConfigChange, onStepChange, resumed])
+
+  return {
+    hasSavedProgress: Boolean(getItem(account)),
+    onClearProgress: handleClearProgress,
+    onResume: handleResume,
+    onSaveConfig: handleSaveConfig,
+    onSaveStep: handleSaveStep,
+    resumed,
+  }
+}

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { animated, Transition } from 'react-spring/renderprops'
 import { RootPortal, springs, useTheme } from '@1hive/1hive-ui'
 import Deployment from './Deployment/Deployment'
@@ -9,7 +9,12 @@ import Setup from './Setup'
 import { STATUS_GARDEN_SETUP } from './statuses'
 
 function Onboarding({ onClose, visible }) {
-  const { status } = useOnboardingState()
+  const { onReset, status } = useOnboardingState()
+
+  const handleOnClose = useCallback(() => {
+    onClose()
+    onReset()
+  }, [onClose, onReset])
 
   return (
     <AnimatedSlider visible={visible}>
@@ -20,7 +25,7 @@ function Onboarding({ onClose, visible }) {
         `}
       >
         {status === STATUS_GARDEN_SETUP ? (
-          <Setup onClose={onClose} />
+          <Setup onClose={handleOnClose} />
         ) : (
           <Deployment />
         )}

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { animated, Transition } from 'react-spring/renderprops'
 import { RootPortal, springs, useTheme } from '@1hive/1hive-ui'
 import Deployment from './Deployment/Deployment'
@@ -9,12 +9,7 @@ import Setup from './Setup'
 import { STATUS_GARDEN_SETUP } from './statuses'
 
 function Onboarding({ onClose, visible }) {
-  const { onReset, status } = useOnboardingState()
-
-  const handleOnClose = useCallback(() => {
-    onClose()
-    onReset()
-  }, [onClose, onReset])
+  const { status } = useOnboardingState()
 
   return (
     <AnimatedSlider visible={visible}>
@@ -25,7 +20,7 @@ function Onboarding({ onClose, visible }) {
         `}
       >
         {status === STATUS_GARDEN_SETUP ? (
-          <Setup onClose={handleOnClose} />
+          <Setup onClose={onClose} />
         ) : (
           <Deployment />
         )}

--- a/src/components/Onboarding/transaction-logic.js
+++ b/src/components/Onboarding/transaction-logic.js
@@ -244,10 +244,12 @@ export function createGardenTxThree(
   // Get action and challenge amount in stable value
   const { honeyTokenLiquidityStable, tokenLiquidity } = liquidity
   const tokenPrice = honeyTokenLiquidityStable / tokenLiquidity
-  const actionAmountStable = bigNum(tokenPrice * actionAmount).toString(10)
-  const challengeAmountStable = bigNum(tokenPrice * challengeAmount).toString(
-    10
-  )
+  const actionAmountStable = bigNum(tokenPrice * actionAmount)
+    .toFixed(0)
+    .toString(10)
+  const challengeAmountStable = bigNum(tokenPrice * challengeAmount)
+    .toFixed(0)
+    .toString(10)
 
   return {
     name: 'Install apps',

--- a/src/components/Onboarding/utils/progress-utils.js
+++ b/src/components/Onboarding/utils/progress-utils.js
@@ -1,8 +1,7 @@
 import { getNetworkType } from '@utils/web3-utils'
 import { dataURLtoFile, textToFile } from '@utils/kit-utils'
 
-export const getStorageKey = account =>
-  `onboarding:${getNetworkType()}:${account}`
+const getStorageKey = account => `onboarding:${getNetworkType()}:${account}`
 
 export const getItem = account => {
   const item = window.localStorage.getItem(getStorageKey(account))

--- a/src/components/Onboarding/utils/progress-utils.js
+++ b/src/components/Onboarding/utils/progress-utils.js
@@ -1,0 +1,45 @@
+import { getNetworkType } from '@utils/web3-utils'
+import { dataURLtoFile, textToFile } from '@utils/kit-utils'
+
+export const getStorageKey = account =>
+  `onboarding:${getNetworkType()}:${account}`
+
+export const getItem = account => {
+  const item = window.localStorage.getItem(getStorageKey(account))
+  return item ? JSON.parse(item) : null
+}
+
+export const removeItem = account => {
+  window.localStorage.removeItem(getStorageKey(account))
+}
+
+export const setItem = (account, item) => {
+  window.localStorage.setItem(getStorageKey(account), JSON.stringify(item))
+}
+
+const GARDEN_ASSETS = ['logo_type', 'logo', 'token_logo']
+
+function recoverBlob(file, type = 'dataUrl') {
+  if (file) {
+    const converter = type === 'dataUrl' ? dataURLtoFile : textToFile
+    return converter(file.content, file.blob.path)
+  }
+
+  return null
+}
+
+export function recoverAssets(config) {
+  GARDEN_ASSETS.forEach(assetType => {
+    const asset = config.garden[assetType]
+    if (asset) {
+      asset.blob = recoverBlob(asset)
+    }
+  })
+
+  const covenantAsset = config.agreement.covenantFile
+  if (covenantAsset) {
+    covenantAsset.blob = recoverBlob(covenantAsset, 'text')
+  }
+
+  return config
+}

--- a/src/providers/Onboarding.js
+++ b/src/providers/Onboarding.js
@@ -135,6 +135,15 @@ function OnboardingProvider({ children }) {
     [handleSaveConfig]
   )
 
+  const handleReset = useCallback(() => {
+    setStatus(STATUS_GARDEN_SETUP)
+    setStep(0)
+    setSteps(Screens)
+    setConfig(DEFAULT_CONFIG)
+    setDeployTransactions([])
+    setGardenAddress('')
+  }, [])
+
   const handleStartDeployment = useCallback(() => {
     setStatus(STATUS_GARDEN_DEPLOYMENT)
   }, [])
@@ -242,6 +251,7 @@ function OnboardingProvider({ children }) {
         onBack: handleBack,
         onConfigChange: handleConfigChange,
         onNext: handleNext,
+        onReset: handleReset,
         onStartDeployment: handleStartDeployment,
         status,
         step,

--- a/src/utils/kit-utils.js
+++ b/src/utils/kit-utils.js
@@ -54,3 +54,23 @@ export const readFile = (reader, file) => {
       reader.readAsText(file)
   }
 }
+
+export function dataURLtoFile(dataurl, filename) {
+  var arr = dataurl.split(',')
+  var mime = arr[0].match(/:(.*?);/)[1]
+  var bstr = atob(arr[1])
+  var n = bstr.length
+  var u8arr = new Uint8Array(n)
+
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n)
+  }
+
+  return new File([u8arr], filename, { type: mime })
+}
+
+export function textToFile(text, fileName) {
+  return new File([text], fileName, {
+    type: 'text/plain',
+  })
+}

--- a/src/utils/kit-utils.js
+++ b/src/utils/kit-utils.js
@@ -56,11 +56,11 @@ export const readFile = (reader, file) => {
 }
 
 export function dataURLtoFile(dataurl, filename) {
-  var arr = dataurl.split(',')
-  var mime = arr[0].match(/:(.*?);/)[1]
-  var bstr = atob(arr[1])
-  var n = bstr.length
-  var u8arr = new Uint8Array(n)
+  const arr = dataurl.split(',')
+  const mime = arr[0].match(/:(.*?);/)[1]
+  const bstr = atob(arr[1])
+  let n = bstr.length
+  const u8arr = new Uint8Array(n)
 
   while (n--) {
     u8arr[n] = bstr.charCodeAt(n)


### PR DESCRIPTION
closes https://github.com/1Hive/gardens/issues/469

- Implemented a hook `useProgressSaver` which handles all the logic of storing the updated config as well as logic indicating wether the user wants to resume a saved progress.
- Implemented basic Box UI to ask the user if they would like to pick up from the last progress saved. 
 **Preview**

This is just a basic UI @fioreb if you can do your magic with this component 🙏  because im not a fan of the result or the texts either 😅 .
![Screen Shot 2021-11-30 at 21 29 00](https://user-images.githubusercontent.com/22663232/144149691-efdb86d3-68d3-4bf9-add9-4d5d63211f3b.png)


Things to consider: 

- When stringifying the config object so it can be stored locally, the logos blob File loses all data expect for the `path`(which indicates the file name). Because of this i implemented a asset recovery function `recoverAssets` which given the content and the name it recovers the original blob data.

