### PR TITLE
Wallet refactor

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -119,8 +119,8 @@ export function getNetworkChainIdByType(networkType) {
   return networks.find(network => network.type === networkType)?.chainId || null
 }
 
-export function getEthersNetwork() {
-  const { type, chainId, ensRegistry } = getNetwork()
+export function getEthersNetwork(chainId) {
+  const { type, ensRegistry } = getNetwork(chainId)
   return {
     name: type,
     chainId: chainId,

--- a/src/providers/Wallet.js
+++ b/src/providers/Wallet.js
@@ -27,14 +27,7 @@ function useWalletAugmented() {
 // Adds Ethers.js to the useWallet() object
 function WalletAugmented({ children }) {
   const wallet = useWallet()
-  const { ethereum, isConnected } = wallet
-
-  const ethers = useMemo(() => {
-    if (!ethereum) {
-      return getDefaultProvider()
-    }
-    return new EthersProviders.Web3Provider(ethereum, getEthersNetwork())
-  }, [ethereum])
+  const { chainId, ethereum, isConnected } = wallet
 
   const {
     connect,
@@ -44,6 +37,16 @@ function WalletAugmented({ children }) {
     resetConnection,
     switchingNetworks,
   } = useConnection()
+
+  const ethers = useMemo(() => {
+    if (!ethereum) {
+      return getDefaultProvider()
+    }
+    return new EthersProviders.Web3Provider(
+      ethereum,
+      getEthersNetwork(isConnected() ? chainId : preferredNetwork)
+    )
+  }, [chainId, ethereum, isConnected, preferredNetwork])
 
   const contextValue = useMemo(
     () => ({


### PR DESCRIPTION
PR to update ethers instance when chainId changes.

Not including this change can cause some contracts that are instantiated with the ethers signer to error (with underlying network change) on performing actions. 