### PR TITLE
Disable sourcemap generation on development and on production

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "yarn run sync-assets && react-app-rewired start",
-    "build": "yarn run sync-assets && react-app-rewired build",
+    "start": "yarn run sync-assets && GENERATE_SOURCEMAP=false react-app-rewired start",
+    "build": "yarn run sync-assets && GENERATE_SOURCEMAP=false react-app-rewired build",
     "lint": "eslint ./src",
     "sync-assets": "copy-aragon-ui-assets ./public",
     "bundlewatch": "bundlewatch",
@@ -94,6 +94,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-standard": "^5.0.0",
+    "immer": "^9.0.7",
     "prettier": "^2.5.1",
     "react-app-polyfill": "^3.0.0",
     "react-app-rewire-provide-plugin": "^1.0.0",
@@ -101,6 +102,7 @@
     "react-dev-utils": "^12.0.0",
     "react-scripts": "^5.0.0",
     "rimraf": "^2.6.2",
+    "source-map-loader": "https://github.com/Volune/source-map-loader.git#fixes",
     "svgo": "^2.8.0",
     "typescript": "^4.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-standard": "^5.0.0",
-    "immer": "^9.0.7",
     "prettier": "^2.5.1",
     "react-app-polyfill": "^3.0.0",
     "react-app-rewire-provide-plugin": "^1.0.0",
@@ -102,7 +101,6 @@
     "react-dev-utils": "^12.0.0",
     "react-scripts": "^5.0.0",
     "rimraf": "^2.6.2",
-    "source-map-loader": "https://github.com/Volune/source-map-loader.git#fixes",
     "svgo": "^2.8.0",
     "typescript": "^4.5.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20144,9 +20144,9 @@ ursa-optional@~0.10.0:
     bindings "^1.5.0"
     nan "^2.14.2"
 
-"use-inside@git+https://github.com/aragon/use-inside.git#16f321e499d8f89e9b0fb0999e2d21db2b119bbf":
+"use-inside@https://github.com/aragon/use-inside#16f321e499d8f89e9b0fb0999e2d21db2b119bbf":
   version "0.2.0"
-  resolved "git+https://github.com/aragon/use-inside.git#16f321e499d8f89e9b0fb0999e2d21db2b119bbf"
+  resolved "https://github.com/aragon/use-inside#16f321e499d8f89e9b0fb0999e2d21db2b119bbf"
 
 "use-wallet@npm:@1hive/use-wallet@0.13.1":
   version "0.13.1"


### PR DESCRIPTION
Right now, this is a common situation with the latest version of the create-react-app since the way source-map-loader is loaded by webpack (ref: https://github.com/mswjs/msw/issues/1030#issuecomment-995760580).

So, for the time being it is better to disable source-maps generation in gardens-ui.


Closes #769 

Note: Please remove the build folder `rm -rf build` and then run the `yarn start` or `yarn build`