### PR TITLE
Ethereum connectors: remove mumbai

### DIFF
--- a/src/ethereum-providers/connectors.ts
+++ b/src/ethereum-providers/connectors.ts
@@ -10,13 +10,13 @@ export const CONNECTORS = [
   {
     id: 'injected',
     properties: {
-      chainId: [100, 4, 137, 80001, 31337], // add here to handle more injected chains
+      chainId: [100, 4, 137, 31337], // add here to handle more injected chains
     },
   },
   {
     id: 'frame',
     properties: {
-      chainId: [100, 4, 137, 80001, 31337],
+      chainId: [100, 4, 137, 31337],
     },
   },
   {


### PR DESCRIPTION
For some reason we were supporting mumbai as one of the allowed chains passed to useWallet now that we are testing the Maroon5 specific gardens we added the mumbai network to metamask and noticed that breaks the app because there is not data  defined for the app on the `networks` file under mumbai attr.

So since the M5 gardens instance is totally apart from our flow and has it own branch i am just removing it.