### PR TITLE
Transaction modal: trx status always failed

### DIFF
--- a/src/providers/ActivityProvider.js
+++ b/src/providers/ActivityProvider.js
@@ -23,8 +23,8 @@ function getStoredList(account, chainId) {
   return new StoredList(`activity:${getNetworkType(chainId)}:${account}`, {
     preStringify: (activity) => ({
       ...activity,
-      status: activity.status.description.replace('ACTIVITY_STATUS_', ''),
-      type: activity.type?.description,
+      status: activity.status.replace('ACTIVITY_STATUS_', ''),
+      type: activity.type,
     }),
     postParse: (activity) => ({
       ...activity,


### PR DESCRIPTION
Since we are using an enum for the status and not symbols anymore the description field does not existe anymore.