### PR TITLE
chore: fix missing source-maps & reduce bundle size

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -10,7 +10,33 @@ const {
 } = require('customize-cra')
 const webpack = require('webpack')
 
+const updateWebpackModuleRules = (config) => {
+  const sourceMapLoader = {
+    enforce: 'pre',
+    exclude: /@babel(?:\/|\\{1,2})runtime/,
+    test: /\.(js|mjs|jsx|ts|tsx|css)$/,
+    use: [
+      {
+        loader: 'source-map-loader',
+        options: {
+          filterSourceMappingUrl: (url, resourcePath) => {
+            if (/.*\/node_modules\/.*/.test(resourcePath)) {
+              return false
+            }
+            return true
+          },
+        },
+      },
+    ],
+  }
+
+  config.module.rules.splice(0, 1, sourceMapLoader)
+
+  return config
+}
+
 module.exports = override(
+  updateWebpackModuleRules,
   useBabelRc(),
   addWebpackAlias({
     '@': path.resolve(__dirname, './src'),

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -39,6 +39,7 @@ module.exports = override(
   updateWebpackModuleRules,
   useBabelRc(),
   addWebpackAlias({
+    'bn.js': 'fork-bn.js',
     '@': path.resolve(__dirname, './src'),
     '@abis': path.resolve(__dirname, './src/abi'),
     '@assets': path.resolve(__dirname, './src/assets'),

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "yarn run sync-assets && GENERATE_SOURCEMAP=false react-app-rewired start",
-    "build": "yarn run sync-assets && GENERATE_SOURCEMAP=false react-app-rewired build",
+    "start": "yarn run sync-assets && react-app-rewired start",
+    "build": "yarn run sync-assets && react-app-rewired build",
     "lint": "eslint ./src",
     "sync-assets": "copy-aragon-ui-assets ./public",
     "bundlewatch": "bundlewatch",
@@ -28,6 +28,7 @@
     "crypto-browserify": "^3.12.0",
     "dayjs": "^1.8.34",
     "ethers": "^5.5.1",
+    "fork-bn.js": "^4.11.8",
     "https-browserify": "^1.0.0",
     "is-ipfs": "^2.0.0",
     "os-browserify": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9397,6 +9397,11 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+fork-bn.js@^4.11.8:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/fork-bn.js/-/fork-bn.js-4.11.8.tgz#839e073b29c20f49035af5f30793081d2397692f"
+  integrity sha512-Z1mCv62QXqnc5aDzfKWNRma2nC8tkOE7HLRoqgBQFTu4jPsJ2DDBnRf3CHlfkrEOsxkQ7NgxVRKFhwttxkdrFA==
+
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.0.tgz#0282b335fa495a97e167f69018f566ea7d2a2b5e"


### PR DESCRIPTION
#### Context

Earlier in #772 , I have disabled source-maps temporarily for suppressing the warnings in the console.

#### Problem Statement

But that disabled source-maps overall for the entire gardens project and it is a bit hard to debug UI issues since it will point to the transpiled code.

#### Solution
This PR fixes the missing source-maps warnings and enables source-maps which would allow us for easy debugging over-all.

Also, apart from that, I installed `fork-bn.js` and aliased all the `bn.js` chunks in the bundle to the `fork-bn.js`. This allowed us to trim off ~46kB from the main bundle.

#### Note:

Please follow the below mentioned steps for testing:

- Remove `node_modules` & `build` folders: `rm -rf node_modules build`
- Install depenedencies `yarn install` or `yarn`
- Run the project in development / production mode.

#### Images

##### Before:
![image](https://user-images.githubusercontent.com/3415488/148583137-108f2038-b2b1-4284-ad30-3a72a8374968.png)

##### After:
![image](https://user-images.githubusercontent.com/3415488/148583179-5f7cd003-0817-4f82-bb9d-dc3328e039c7.png)

