### PR TITLE
GardenNameResolver: disable ethers ens resolver

### DIFF
--- a/src/hooks/useGardenNameResolver.ts
+++ b/src/hooks/useGardenNameResolver.ts
@@ -1,30 +1,41 @@
 import { useEffect, useState } from 'react'
+import {useGardens} from '@providers/Gardens'
 import { useWallet } from '@providers/Wallet'
 import { isAddress } from '@utils/web3-utils'
 
 const ARAGON_DOMAIN = 'aragonid.eth'
 
+
+// seems that the ens resolver is still no ready for L2 on ehters
+// see https://github.com/ethers-io/ethers.js/issues/2003#issuecomment-1006249747
 export default function useGardenNameResolver(gardenId: string) {
-  const [gardenAddress, setGardenAddress] = useState('')
-  const { ethers } = useWallet()
+  const {gardens} = useGardens()
+  // const [gardenAddress, setGardenAddress] = useState('')
+  // const { ethers } = useWallet()
 
-  useEffect(() => {
-    if (!gardenId || isAddress(gardenId)) {
-      setGardenAddress(gardenId || '')
-      return
-    }
+  // useEffect(() => {
+  //   if (!gardenId || isAddress(gardenId)) {
+  //     setGardenAddress(gardenId || '')
+  //     return
+  //   }
 
-    const resolveName = async () => {
-      try {
-        const address = await ethers.resolveName(`${gardenId}.${ARAGON_DOMAIN}`)
-        setGardenAddress(address)
-      } catch (err) {
-        console.error(`Error resolving garden name: ${err}`)
-      }
-    }
+  //   const resolveName = async () => {
+  //     try {
+  //       const address = await ethers.resolveName(`${gardenId}.${ARAGON_DOMAIN}`)
+  //       setGardenAddress(address)
+  //     } catch (err) {
+  //       console.error(`Error resolving garden name: ${err}`)
+  //     }
+  //   }
 
-    resolveName()
-  }, [ethers, gardenId])
+  //   resolveName()
+  // }, [ethers, gardenId])
 
-  return gardenAddress
+  return getGardenAddressByName(gardenId, gardens)
+}
+
+//TODO - remove this function once ethers support resolver on L2
+function getGardenAddressByName(gardenName: string, gardens:[any]){
+  const garden = gardens.find(g => g?.name?.toLowerCase() === gardenName.toLowerCase())
+  return garden?.address
 }

--- a/src/hooks/useGardenNameResolver.ts
+++ b/src/hooks/useGardenNameResolver.ts
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react'
+// import { useEffect, useState } from 'react'
 import {useGardens} from '@providers/Gardens'
-import { useWallet } from '@providers/Wallet'
-import { isAddress } from '@utils/web3-utils'
+// import { useWallet } from '@providers/Wallet'
+// import { isAddress } from '@utils/web3-utils'
 
-const ARAGON_DOMAIN = 'aragonid.eth'
+// const ARAGON_DOMAIN = 'aragonid.eth'
 
 
 // seems that the ens resolver is still no ready for L2 on ehters


### PR DESCRIPTION
Left the reasons wrote on the code. Left code commented to re enable once ethers 6 is out

Closes <https://github.com/1Hive/gardens/issues/505>