### PR TITLE
Fix: LocalStorage exceed Onboarding 

### DIFF
--- a/src/components/Onboarding/hooks/useProgressSaver.ts
+++ b/src/components/Onboarding/hooks/useProgressSaver.ts
@@ -8,7 +8,10 @@ import {
   setItem,
 } from '../utils/progress-utils'
 
-export default function useProgressSaver(onConfigChange, onStepChange) {
+export default function useProgressSaver(
+  onConfigChange: any,
+  onStepChange: any
+) {
   const { account, chainId } = useWallet()
   const [resumed, setResumed] = useState(false)
 
@@ -21,7 +24,7 @@ export default function useProgressSaver(onConfigChange, onStepChange) {
   }, [])
 
   const handleSaveConfig = useCallback(
-    config => {
+    (config) => {
       const progress = getItem(account, chainId)
       setItem(account, chainId, { ...progress, config })
     },
@@ -29,7 +32,7 @@ export default function useProgressSaver(onConfigChange, onStepChange) {
   )
 
   const handleSaveStep = useCallback(
-    step => {
+    (step) => {
       const progress = getItem(account, chainId)
       setItem(account, chainId, { ...progress, step })
     },

--- a/src/components/Onboarding/utils/progress-utils.ts
+++ b/src/components/Onboarding/utils/progress-utils.ts
@@ -1,19 +1,19 @@
 import { getNetworkType } from '@utils/web3-utils'
 import { dataURLtoFile, textToFile } from '@utils/kit-utils'
 
-const getStorageKey = (account, chainId) =>
+const getStorageKey = (account: string, chainId: number) =>
   `onboarding:${getNetworkType(chainId)}:${account}`
 
-export const getItem = (account, chainId) => {
+export const getItem = (account: string, chainId: number) => {
   const item = window.localStorage.getItem(getStorageKey(account, chainId))
   return item ? JSON.parse(item) : null
 }
 
-export const removeItem = account => {
-  window.localStorage.removeItem(getStorageKey(account))
+export const removeItem = (account: string, chainId: number) => {
+  window.localStorage.removeItem(getStorageKey(account, chainId))
 }
 
-export const setItem = (account, chainId, item) => {
+export const setItem = (account: string, chainId: number, item: any) => {
   window.localStorage.setItem(
     getStorageKey(account, chainId),
     JSON.stringify(item)
@@ -22,7 +22,10 @@ export const setItem = (account, chainId, item) => {
 
 const GARDEN_ASSETS = ['logo_type', 'logo', 'token_logo']
 
-function recoverBlob(file, type = 'dataUrl') {
+function recoverBlob(
+  file?: { content: any; blob: { path: any } },
+  type = 'dataUrl'
+) {
   if (file) {
     const converter = type === 'dataUrl' ? dataURLtoFile : textToFile
     return converter(file.content, file.blob.path)
@@ -31,8 +34,11 @@ function recoverBlob(file, type = 'dataUrl') {
   return null
 }
 
-export function recoverAssets(config) {
-  GARDEN_ASSETS.forEach(assetType => {
+export function recoverAssets(config: {
+  garden: { [x: string]: any }
+  agreement: { covenantFile: any }
+}) {
+  GARDEN_ASSETS.forEach((assetType) => {
     const asset = config.garden[assetType]
     if (asset) {
       asset.blob = recoverBlob(asset)

--- a/src/components/Onboarding/utils/progress-utils.ts
+++ b/src/components/Onboarding/utils/progress-utils.ts
@@ -14,10 +14,14 @@ export const removeItem = (account: string, chainId: number) => {
 }
 
 export const setItem = (account: string, chainId: number, item: any) => {
-  window.localStorage.setItem(
-    getStorageKey(account, chainId),
-    JSON.stringify(item)
-  )
+  try {
+    window.localStorage.setItem(
+      getStorageKey(account, chainId),
+      JSON.stringify(item)
+    )
+  } catch (error) {
+    throw new Error('Disk space exceed. Clear your cache.')
+  }
 }
 
 const GARDEN_ASSETS = ['logo_type', 'logo', 'token_logo']

--- a/src/utils/kit-utils.js
+++ b/src/utils/kit-utils.js
@@ -23,7 +23,7 @@ export const toOxford = (arr, conjunction = 'and', ifempty = '') => {
   return arr.join(', ')
 }
 
-export const mimeToExtension = mime => {
+export const mimeToExtension = (mime) => {
   switch (mime) {
     case 'text/markdown':
       return '.md'
@@ -58,7 +58,7 @@ export const readFile = (reader, file) => {
 export function dataURLtoFile(dataurl, filename) {
   const arr = dataurl.split(',')
   const mime = arr[0].match(/:(.*?);/)[1]
-  const bstr = atob(arr[1])
+  const bstr = window.atob(arr[1])
   let n = bstr.length
   const u8arr = new Uint8Array(n)
 


### PR DESCRIPTION
It solves - https://github.com/1Hive/gardens/issues/498

That PR fix the problem accumulating and never removing onboarding state, but need user clear your cache in case it get full for another reason.

### Update
With the last commit - https://github.com/1Hive/gardens-ui/pull/789/commits/7e71b116a657a34470343ba0b9339423df5c3ed8
Its possible get better handling errors, but it not solve the storage full.

### Suggestion to improvement
The suggestion will be pop-up some button to click and clear localStorage.
The question is: Has some localstorage key we should keep?