### PR TITLE
Upgrade to EVMcrispr v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@1hive/connect-agreement": "^0.9.5",
     "@1hive/connect-gardens": "^0.1.12",
     "@1hive/connect-react": "^0.9.9",
-    "@1hive/evmcrispr": "^0.3.2",
+    "@1hive/evmcrispr": "^0.3.4",
     "@juggle/resize-observer": "^3.2.0",
     "@nivo/core": "^0.73.0",
     "@nivo/line": "^0.73.0",

--- a/src/components/Garden/Preferences/EVMExecutor.js
+++ b/src/components/Garden/Preferences/EVMExecutor.js
@@ -207,7 +207,7 @@ function EVMExecutor({ evmcrispr }) {
       }
     }
 
-    return [{ ...intent.action, description: description, type: type }]
+    return [{ ...intent.action, description, type, gasLimit: 10000000 }]
   }, [
     forwarderName,
     interactionType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,10 +192,10 @@
     "@1hive/connect-ethereum" "^0.9.10"
     "@1hive/connect-thegraph" "^0.9.10"
 
-"@1hive/evmcrispr@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@1hive/evmcrispr/-/evmcrispr-0.3.2.tgz#d006a538e07bb5d9c5aeec4f24ef68a6c1ffdbb0"
-  integrity sha512-n/rebDdUQYMwEggbOY/t2Da1E0UZexGCxnhg16Z7MaNTScQX0qYfYxB/OXaAMmBGKJvGGNBqMVJxP3xVQEpkiA==
+"@1hive/evmcrispr@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@1hive/evmcrispr/-/evmcrispr-0.3.4.tgz#8258b8a698fc1d28eda80ca88ec37cb7246d4e8d"
+  integrity sha512-QwW340ClXUKyMF/tqZwsZebDFWZLe8QXiFL+MdvEakz5GV3IqbbAaY/ZOw9diTCyXAvxr0uy37v1/GY1pEfvxg==
   dependencies:
     "@1hive/connect" "^0.9.7"
     ethers "^5.0.17"


### PR DESCRIPTION
There are many fixes in the last two releases that affect both EVM Executor and EVM Terminal:

New features:

* New command that introduces the ability to upgrade apps.
* You can pass strings with spaces now to the console using double-quote notation.
* It now supports time units in numeric parameters (such as 1s for 1 second, 1m for 1 minute, 1h for 1 hour...).

Fixes:

* It now recognizes fixed-size array parameters, needed in some agent calls.
* It now loads DAO apps even if some of them don’t have a reachable artifact.
* It now recognizes properly "false" as a false boolean in exec, act, and install commands.