### PR TITLE
Feat: include custom get token link

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -217,6 +217,8 @@ type GardenNavItemsProps = {
     wrappableToken: any
     token: any
     wiki: any
+    forumURL: string
+    getTokenLink: string
   }
 }
 
@@ -224,14 +226,19 @@ function GardenNavItems({ garden }: GardenNavItemsProps) {
   const theme = useTheme()
   const history = useHistory()
   const token = garden.wrappableToken || garden.token
-  const connectedGarden = useConnectedGarden()
-  const forumURL = connectedGarden.forumURL
+  const forumURL = garden.forumURL
   const { preferredNetwork } = useWallet()
 
   const handleOnGoToCovenant = useCallback(() => {
     const path = buildGardenPath(history.location, 'covenant')
     history.push(path)
   }, [history])
+
+  const getTokenLink = useMemo(
+    () =>
+      garden?.getTokenLink || getDexTradeTokenUrl(preferredNetwork, token.id),
+    [garden]
+  )
 
   return (
     <>
@@ -247,7 +254,7 @@ function GardenNavItems({ garden }: GardenNavItemsProps) {
         Forum
       </Link>
       <Link
-        href={getDexTradeTokenUrl(preferredNetwork, token.id)}
+        href={getTokenLink}
         css={`
           text-decoration: none;
           color: ${theme.contentSecondary};

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,7 +1,7 @@
 import { getNetworkName } from '@utils/web3-utils'
 import env from '@/environment'
 
-const OWNER_REPO = env('OWNER_REPO_DAO_LIST') ?? 'kamikazebr' //TODO: Change or remove it after tests
+const OWNER_REPO = env('OWNER_REPO_DAO_LIST') ?? '1Hive'
 const REPO = 'dao-list'
 
 const ASSETS_FOLDER_BASE = `https://raw.githubusercontent.com/${OWNER_REPO}/${REPO}/master/assets`


### PR DESCRIPTION
This new feature is important for TEC because they use the https://convert.tecommons.org instead of Honeyswap.