### PR TITLE
[Feature] Add Discord url pattern to forumURL at Create Proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint ./src",
     "sync-assets": "copy-aragon-ui-assets ./public",
     "bundlewatch": "bundlewatch",
-    "prettier-ai": "prettier --write 'src/**/*.{ts,tsx,js}' --loglevel=error --ignore-path .prettier-imports-ignore"
+    "prettier-ai": "prettier --write 'src/**/*.{ts,tsx,js}' --loglevel=error --ignore-path .prettier-imports-ignore",
+    "test": "react-app-rewired test --env=jsdom"
   },
   "dependencies": {
     "3box": "^1.19.1",
@@ -64,11 +65,24 @@
       "last 1 safari version"
     ]
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^@assets(.*)$": "<rootDir>/src/assets$1",
+      "^@abis(.*)$": "<rootDir>/src/abi$1",
+      "^@components(.*)$": "<rootDir>/src/components$1",
+      "^@hooks(.*)$": "<rootDir>/src/hooks$1",
+      "^@lib(.*)$": "<rootDir>/src/lib$1",
+      "^@providers(.*)$": "<rootDir>/src/providers$1",
+      "^@utils(.*)$": "<rootDir>/src/utils$1",
+      "^@/(.*)$": "<rootDir>/src/$1"
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.16.5",
     "@babel/plugin-proposal-class-properties": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-react": "^7.16.5",
+    "@types/jest": "^27.4.0",
     "@types/node": "^16.11.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
@@ -62,7 +62,10 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
   const fundingMode = formData.proposalType === FUNDING_PROPOSAL
 
   const forumRegex = new RegExp(
-    /https:\/\/(forum\.1hive\.org|discord\.com\/channels)\//
+    String.raw`(${connectedGarden.forumURL.replace(
+      /[-/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    )}|https:\/\/discord\.com\/channels\/)`
   )
 
   const handleAmountEditMode = useCallback(

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
@@ -61,11 +61,14 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
 
   const fundingMode = formData.proposalType === FUNDING_PROPOSAL
 
+  // Escaping forumURL to avoid misuse with regexp
+  const forumURLRegex = connectedGarden.forumURL.replace(
+    /[-/\\^$*+?.()|[\]{}]/g,
+    '\\$&'
+  )
+
   const forumRegex = new RegExp(
-    String.raw`(${connectedGarden.forumURL.replace(
-      /[-/\\^$*+?.()|[\]{}]/g,
-      '\\$&'
-    )}|https:\/\/discord\.com\/channels\/)`
+    String.raw`(${forumURLRegex}|https:\/\/discord\.com\/channels\/)`
   )
 
   const handleAmountEditMode = useCallback(

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
@@ -20,6 +20,7 @@ import { useMultiModal } from '@components/MultiModal/MultiModalProvider'
 import { usePriceOracle } from '@hooks/usePriceOracle'
 import BigNumber from '@lib/bigNumber'
 import { toDecimals } from '@utils/math-utils'
+import { escapeRegex, regexToCheckValidProposalURL } from '@utils/regex-utils'
 import { formatTokenAmount, isStableToken } from '@utils/token-utils'
 import { calculateThreshold, getMaxConviction } from '@lib/conviction'
 
@@ -62,13 +63,8 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
   const fundingMode = formData.proposalType === FUNDING_PROPOSAL
 
   // Escaping forumURL to avoid misuse with regexp
-  const forumURLRegex = connectedGarden.forumURL.replace(
-    /[-/\\^$*+?.()|[\]{}]/g,
-    '\\$&'
-  )
-
-  const forumRegex = new RegExp(
-    String.raw`(${forumURLRegex}|https:\/\/discord\.com\/channels\/)`
+  const forumRegex = regexToCheckValidProposalURL(
+    escapeRegex(connectedGarden.forumURL)
   )
 
   const handleAmountEditMode = useCallback(

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
@@ -61,11 +61,13 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
 
   const fundingMode = formData.proposalType === FUNDING_PROPOSAL
 
-  const forumRegex = new RegExp(connectedGarden.forumURL)
+  const forumRegex = new RegExp(
+    /https:\/\/(forum\.1hive\.org|discord\.com\/channels)\//
+  )
 
   const handleAmountEditMode = useCallback(
-    editMode => {
-      setFormData(formData => {
+    (editMode) => {
+      setFormData((formData) => {
         const { amount } = formData
 
         const newValue = amount.valueBN.gte(0)
@@ -94,20 +96,20 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
     [stakeToken]
   )
 
-  const handleIsStableChange = useCallback(checked => {
-    setFormData(formData => ({
+  const handleIsStableChange = useCallback((checked) => {
+    setFormData((formData) => ({
       ...formData,
       amount: { ...formData.amount, stable: checked },
     }))
   }, [])
 
-  const handleTitleChange = useCallback(event => {
+  const handleTitleChange = useCallback((event) => {
     const updatedTitle = event.target.value
-    setFormData(formData => ({ ...formData, title: updatedTitle }))
+    setFormData((formData) => ({ ...formData, title: updatedTitle }))
   }, [])
 
   const handleAmountChange = useCallback(
-    event => {
+    (event) => {
       const updatedAmount = event.target.value
 
       const newAmountBN = new BigNumber(
@@ -116,7 +118,7 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
           : toDecimals(updatedAmount, stakeToken.decimals)
       )
 
-      setFormData(formData => ({
+      setFormData((formData) => ({
         ...formData,
         amount: {
           ...formData.amount,
@@ -128,26 +130,29 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
     [stakeToken.decimals]
   )
 
-  const handleProposalTypeChange = useCallback(selected => {
-    setFormData(formData => ({
+  const handleProposalTypeChange = useCallback((selected) => {
+    setFormData((formData) => ({
       ...formData,
       proposalType: selected,
     }))
   }, [])
 
-  const handleBeneficiaryChange = useCallback(event => {
+  const handleBeneficiaryChange = useCallback((event) => {
     const updatedBeneficiary = event.target.value
 
-    setFormData(formData => ({ ...formData, beneficiary: updatedBeneficiary }))
+    setFormData((formData) => ({
+      ...formData,
+      beneficiary: updatedBeneficiary,
+    }))
   }, [])
 
-  const handleLinkChange = useCallback(event => {
+  const handleLinkChange = useCallback((event) => {
     const updatedLink = event.target.value
-    setFormData(formData => ({ ...formData, link: updatedLink }))
+    setFormData((formData) => ({ ...formData, link: updatedLink }))
   }, [])
 
   const handleOnContinue = useCallback(
-    event => {
+    (event) => {
       event.preventDefault()
 
       setProposalData(formData)
@@ -178,7 +183,7 @@ const AddProposalPanel = React.memo(({ setProposalData }) => {
     }
 
     if (link && !forumRegex.test(link)) {
-      errors.push('Forum post link not provided ')
+      errors.push('Forum post link not provided or not valid')
     }
 
     return errors

--- a/src/utils/__tests__/regex-utils.test.ts
+++ b/src/utils/__tests__/regex-utils.test.ts
@@ -1,0 +1,20 @@
+import { escapeRegex, regexToCheckValidProposalURL } from '@utils/regex-utils'
+
+describe('Test regexToCheckValidProposalURL()', () => {
+  it('should test https://forum.1hive.org/ and pass', () => {
+    const regex = regexToCheckValidProposalURL('https://forum.1hive.org/')
+
+    expect(regex.test('http://forum.1hive.org/')).toBeFalsy()
+    expect(regex.test('http://forum.1hive.org')).toBeFalsy()
+    expect(regex.test('https://forum.1hive.org/')).toBeTruthy()
+    expect(regex.test('https://forum.1hive.org')).toBeFalsy()
+  })
+})
+describe('Escape all Regex symbols with escapeRegex()', () => {
+  it('should escape - / ^ $ * + ? . ( ) \\ { }', () => {
+    const escape1 = escapeRegex('https://forum.1hive.org/')
+    const escape2 = escapeRegex('(forum.*?).1hive.org/')
+    expect(escape1).toBe('https:\\/\\/forum\\.1hive\\.org\\/')
+    expect(escape2).toBe('\\(forum\\.\\*\\?\\)\\.1hive\\.org\\/')
+  })
+})

--- a/src/utils/regex-utils.ts
+++ b/src/utils/regex-utils.ts
@@ -1,0 +1,13 @@
+export function regexToCheckValidProposalURL(proposalURLRegex: string) {
+  return new RegExp(
+    String.raw`(${proposalURLRegex}|https:\/\/discord\.com\/channels\/)`
+  )
+}
+/**
+ * Escape regex special chars addind backslash before each char.
+ * @param toEscape - string to be escaped
+ * @returns string safe to use in Regex
+ */
+export function escapeRegex(toEscape: string) {
+  return toEscape.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3037,6 +3037,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^27.4.0":
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
+  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
+  dependencies:
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -12106,6 +12114,16 @@ jest-config@^27.4.5:
     pretty-format "^27.4.2"
     slash "^3.0.0"
 
+jest-diff@^27.0.0:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.6.tgz#93815774d2012a2cbb6cf23f84d48c7a2618f98d"
+  integrity sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.4.0"
+    jest-get-type "^27.4.0"
+    pretty-format "^27.4.6"
+
 jest-diff@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.2.tgz#786b2a5211d854f848e2dcc1e324448e9481f36f"
@@ -16739,6 +16757,15 @@ pretty-error@^4.0.0:
   dependencies:
     lodash "^4.17.20"
     renderkid "^3.0.0"
+
+pretty-format@^27.0.0, pretty-format@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.6.tgz#1b784d2f53c68db31797b2348fa39b49e31846b7"
+  integrity sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 pretty-format@^27.4.2:
   version "27.4.2"


### PR DESCRIPTION
The Regexp added to threat **forum.1hive.org** and **discord channels/threads**

Just allowing HTTPS and url ending with slash.

Running Tests:

![image](https://user-images.githubusercontent.com/691510/151428946-8bb42c06-35bb-4cd1-87f7-8d79aafd6554.png)

In Create Proposal screen:
![image](https://user-images.githubusercontent.com/691510/151258755-9f845731-11fd-414d-9ef6-62f4bd636a2c.png)


~Note: The previous implementation used the `forumURL` setted in Onboarding Screen as reference to Create Proposal.~

- Integrated the `forumUrl` to regexp together with discord regexp

