### PR TITLE
Improve writting in fluid proposals

### DIFF
--- a/src/components/Garden/ProposalDetail/ProposalDetail.js
+++ b/src/components/Garden/ProposalDetail/ProposalDetail.js
@@ -262,14 +262,14 @@ function ProposalDetail({
                                   <strong>
                                     {proposal?.currentRate.monthly}
                                   </strong>{' '}
-                                  {requestToken.symbol} per month with a cap of{' '}
+                                  {requestToken.symbol}/month {parseFloat(proposal?.currentRate.monthly || '0') < parseFloat(proposal?.targetRate.monthly || '0') ? 'increasing' : 'decreasing'} to a target flow of{' '}
                                   <strong>
-                                    {proposal?.targetRate.monthly}
+                                    {proposal?.targetRate.monthly} {requestToken.symbol}/month
                                   </strong>
                                 </span>
                                 <Help hint="">
                                   Stream proposals accrue in relation with the
-                                  support amount, reaching a maximum cap.
+                                  support amount, reaching the target ratio after a while.
                                 </Help>
                               </div>
                             ) : (

--- a/src/components/Garden/Stream.tsx
+++ b/src/components/Garden/Stream.tsx
@@ -37,8 +37,8 @@ export function Stream({
         `}
       >
         <TokenIcon src={icon} />
-        {currentRate?.monthly} {symbol} per month with a cap of{' '}
-        {targetRate?.monthly}
+        {currentRate?.monthly} {symbol}/mo {parseFloat(currentRate?.monthly || '0s') < parseFloat(targetRate?.monthly || '0') ? 'increasing' : 'decreasing'} to a target flow of {' '}
+        {targetRate?.monthly} {symbol}/mo
       </div>
     </section>
   )


### PR DESCRIPTION
It shows a more accurate message in the streaming proposals:

![Screenshot from 2022-11-04 17-21-03](https://user-images.githubusercontent.com/931684/200083289-40a67cad-519a-402b-8bc4-c337c21e6a98.png)
